### PR TITLE
generic: fix realtek PHY detection patch

### DIFF
--- a/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -13,7 +13,15 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -744,6 +744,38 @@ static int rtl8226_match_phy_device(stru
+@@ -79,6 +79,7 @@
+ #define RTLGEN_SPEED_MASK			0x0630
+ 
+ #define RTL_GENERIC_PHYID			0x001cc800
++#define RTL_8221B_VB_CG_PHYID			0x001cc849
+ 
+ MODULE_DESCRIPTION("Realtek PHY driver");
+ MODULE_AUTHOR("Johnson Leung");
+@@ -744,6 +745,38 @@ static int rtl8226_match_phy_device(stru
  	       rtlgen_supports_2_5gbps(phydev);
  }
  
@@ -46,13 +54,13 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		id |= val;
 +	}
 +
-+	return (id == 0x001cc849);
++	return (id == RTL_8221B_VB_CG_PHYID);
 +}
 +
  static int rtl822x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -1082,7 +1114,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1082,7 +1115,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {

--- a/target/linux/generic/pending-5.15/731-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-5.15/731-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -971,6 +971,51 @@ static int rtl8221b_config_init(struct p
+@@ -972,6 +972,51 @@ static int rtl8221b_config_init(struct p
  	return 0;
  }
  
@@ -64,7 +64,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1119,6 +1164,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1120,6 +1165,8 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,

--- a/target/linux/generic/pending-6.1/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.1/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -13,7 +13,15 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -754,6 +754,38 @@ static int rtl8226_match_phy_device(stru
+@@ -80,6 +80,7 @@
+ 
+ #define RTL_GENERIC_PHYID			0x001cc800
+ #define RTL_8211FVD_PHYID			0x001cc878
++#define RTL_8221B_VB_CG_PHYID			0x001cc849
+ 
+ MODULE_DESCRIPTION("Realtek PHY driver");
+ MODULE_AUTHOR("Johnson Leung");
+@@ -754,6 +755,38 @@ static int rtl8226_match_phy_device(stru
  	       rtlgen_supports_2_5gbps(phydev);
  }
  
@@ -46,13 +54,13 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		id |= val;
 +	}
 +
-+	return (id == 0x001cc849);
++	return (id == RTL_8221B_VB_CG_PHYID);
 +}
 +
  static int rtl822x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -1104,7 +1136,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1104,7 +1137,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {

--- a/target/linux/generic/pending-6.1/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.1/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -981,6 +981,51 @@ static int rtl8221b_config_init(struct p
+@@ -982,6 +982,51 @@ static int rtl8221b_config_init(struct p
  	return 0;
  }
  
@@ -64,7 +64,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1141,6 +1186,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1142,6 +1187,8 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,

--- a/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -34,7 +34,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	u32 id;
 +
 +	if (phydev->is_c45) {
-+		if (phydev->c45_ids.device_ids[1])
++		if (phydev->c45_ids.device_ids[1] != 0xFFFFFFFF)
 +			return phydev->c45_ids.device_ids[1] == RTL_8221B_VB_CG;
 +	} else {
 +		if (phydev->phy_id)

--- a/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -20,7 +20,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  #define RTL_GENERIC_PHYID			0x001cc800
  #define RTL_8211FVD_PHYID			0x001cc878
-+#define RTL_8221B_VB_CG				0x001cc849
++#define RTL_8221B_VB_CG_PHYID			0x001cc849
  
  MODULE_DESCRIPTION("Realtek PHY driver");
  MODULE_AUTHOR("Johnson Leung");
@@ -35,10 +35,10 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +
 +	if (phydev->is_c45) {
 +		if (phydev->c45_ids.device_ids[1] != 0xFFFFFFFF)
-+			return phydev->c45_ids.device_ids[1] == RTL_8221B_VB_CG;
++			return phydev->c45_ids.device_ids[1] == RTL_8221B_VB_CG_PHYID;
 +	} else {
 +		if (phydev->phy_id)
-+			return phydev->phy_id == RTL_8221B_VB_CG;
++			return phydev->phy_id == RTL_8221B_VB_CG_PHYID;
 +	}
 +
 +	if (phydev->mdio.bus->read_c45) {
@@ -65,7 +65,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		id |= val;
 +	}
 +
-+	if (id != RTL_8221B_VB_CG)
++	if (id != RTL_8221B_VB_CG_PHYID)
 +		return 0;
 +
 +	if (phydev->is_c45)


### PR DESCRIPTION
Fixes the issue of RTL8221B-VB-CG not being detected correctly.
Additionally, the constant RTL_8221B_VB_CG_PHYID is used instead of a numeric value for all kernels.
