### PR TITLE
kernel: add new kmod and update kmod-tpm

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -519,6 +519,17 @@ endef
 
 $(eval $(call KernelPackage,crypto-hw-eip93))
 
+define KernelPackage/crypto-aescfb
+  TITLE:=AES cipher operations feedback mode
+  DEPENDS:=@LINUX_6_12
+  KCONFIG:=CONFIG_CRYPTO_LIB_AESCFB
+  FILES:=$(LINUX_DIR)/lib/crypto/libaescfb.ko
+  AUTOLOAD:=$(call AutoLoad,09,libaescfb)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-aescfb))
+
 define KernelPackage/crypto-kpp
   TITLE:=Key-agreement Protocol Primitives
   KCONFIG:=CONFIG_CRYPTO_KPP

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1041,7 +1041,11 @@ define KernelPackage/tpm
   SUBMENU:=$(OTHER_MENU)
   TITLE:=TPM Hardware Support
   DEPENDS:= +kmod-random-core +kmod-asn1-decoder \
-	  +kmod-asn1-encoder +kmod-oid-registry
+	  +kmod-asn1-encoder +kmod-oid-registry \
+	  +LINUX_6_12:kmod-crypto-ecdh \
+	  +LINUX_6_12:kmod-crypto-kpp \
+	  +LINUX_6_12:kmod-crypto-aescfb
+
   KCONFIG:= CONFIG_TCG_TPM
   FILES:= $(LINUX_DIR)/drivers/char/tpm/tpm.ko
   AUTOLOAD:=$(call AutoLoad,10,tpm,1)


### PR DESCRIPTION
Create a crypto-aescfb package needed for new deps for kmod-tpm

Package kmod-tpm is missing dependencies for the following libraries: ecdh_generic.ko
kpp.ko
libaescfb.ko