### PR TITLE
kernel: split nf-nathelper-extra into individual packages

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -201,27 +201,6 @@ $(eval $(call nf_add,NF_NATHELPER,CONFIG_NF_CONNTRACK_FTP, $(P_XT)nf_conntrack_f
 $(eval $(call nf_add,NF_NATHELPER,CONFIG_NF_NAT_FTP, $(P_XT)nf_nat_ftp))
 
 
-# nathelper-extra
-
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_BROADCAST, $(P_XT)nf_conntrack_broadcast))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_NETBIOS_NS, $(P_XT)nf_conntrack_netbios_ns))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_SANE, $(P_XT)nf_conntrack_sane))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_AMANDA, $(P_XT)nf_conntrack_amanda))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_NAT_AMANDA, $(P_XT)nf_nat_amanda))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_H323, $(P_XT)nf_conntrack_h323))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_NAT_H323, $(P_V4)nf_nat_h323))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_PPTP, $(P_XT)nf_conntrack_pptp))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_NAT_PPTP, $(P_V4)nf_nat_pptp))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_SIP, $(P_XT)nf_conntrack_sip))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_NAT_SIP, $(P_XT)nf_nat_sip))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_SNMP, $(P_XT)nf_conntrack_snmp))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_NAT_SNMP_BASIC, $(P_V4)nf_nat_snmp_basic))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_TFTP, $(P_XT)nf_conntrack_tftp))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_NAT_TFTP, $(P_XT)nf_nat_tftp))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_CONNTRACK_IRC, $(P_XT)nf_conntrack_irc))
-$(eval $(call nf_add,NF_NATHELPER_EXTRA,CONFIG_NF_NAT_IRC, $(P_XT)nf_nat_irc))
-
-
 # nflog
 
 $(eval $(call nf_add,IPT_NFLOG,CONFIG_NETFILTER_XT_TARGET_NFLOG, $(P_XT)xt_NFLOG))

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -512,7 +512,7 @@ define KernelPackage/nf-ipvs-sip
   SUBMENU:=$(NF_MENU)
   TITLE:=Virtual Server SIP protocol support
   KCONFIG:=CONFIG_IP_VS_PE_SIP
-  DEPENDS:=kmod-nf-ipvs +kmod-nf-nathelper-extra
+  DEPENDS:=kmod-nf-ipvs +kmod-nf-nathelper-sip
   FILES:=$(LINUX_DIR)/net/netfilter/ipvs/ip_vs_pe_sip.ko
 endef
 
@@ -621,28 +621,192 @@ $(eval $(call KernelPackage,nf-nathelper))
 define KernelPackage/nf-nathelper-extra
   SUBMENU:=$(NF_MENU)
   TITLE:=Extra Conntrack and NAT helpers
-  KCONFIG:=$(KCONFIG_NF_NATHELPER_EXTRA)
-  FILES:=$(foreach mod,$(NF_NATHELPER_EXTRA-m),$(LINUX_DIR)/net/$(mod).ko)
-  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_NATHELPER_EXTRA-m)))
-  DEPENDS:=+kmod-nf-nat +kmod-lib-textsearch +kmod-asn1-decoder
+  DEPENDS:= \
+	+kmod-nf-nathelper-amanda \
+	+kmod-nf-nathelper-broadcast \
+	+kmod-nf-nathelper-h323 \
+	+kmod-nf-nathelper-irc \
+	+kmod-nf-nathelper-netbios \
+	+kmod-nf-nathelper-pptp \
+	+kmod-nf-nathelper-sane \
+	+kmod-nf-nathelper-sip \
+	+kmod-nf-nathelper-snmp \
+	+kmod-nf-nathelper-tftp
 endef
 
 define KernelPackage/nf-nathelper-extra/description
- Extra Netfilter (IPv4) Conntrack and NAT helpers
- Includes:
+ Compatibility package providing all extra Netfilter
+ conntrack and NAT helpers.
+ This package depends on all individual helper packages:
  - amanda
+ - broadcast
  - h323
  - irc
- - mms
+ - netbios
  - pptp
- - proto_gre
+ - sane
  - sip
- - snmp_basic
+ - snmp
  - tftp
- - broadcast
+ Select individual helper packages instead if only a
+ subset is required.
 endef
 
 $(eval $(call KernelPackage,nf-nathelper-extra))
+
+
+define KernelPackage/nf-nathelper-amanda
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Amanda conntrack and NAT helper
+  KCONFIG:= \
+	CONFIG_NF_CONNTRACK_AMANDA \
+	CONFIG_NF_NAT_AMANDA
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_amanda.ko \
+	$(LINUX_DIR)/net/$(P_XT)nf_nat_amanda.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_amanda nf_nat_amanda)
+  DEPENDS:=+kmod-nf-nat +kmod-lib-textsearch
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-amanda))
+
+
+define KernelPackage/nf-nathelper-broadcast
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Broadcast conntrack helper
+  KCONFIG:=CONFIG_NF_CONNTRACK_BROADCAST
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_broadcast.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_broadcast)
+  DEPENDS:=+kmod-nf-conntrack
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-broadcast))
+
+
+define KernelPackage/nf-nathelper-h323
+  SUBMENU:=$(NF_MENU)
+  TITLE:=H.323 conntrack and NAT helper
+  KCONFIG:= \
+	CONFIG_NF_CONNTRACK_H323 \
+	CONFIG_NF_NAT_H323
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_h323.ko \
+	$(LINUX_DIR)/net/$(P_V4)nf_nat_h323.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_h323 nf_nat_h323)
+  DEPENDS:=+kmod-nf-nat
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-h323))
+
+
+define KernelPackage/nf-nathelper-irc
+  SUBMENU:=$(NF_MENU)
+  TITLE:=IRC conntrack and NAT helper
+  KCONFIG:= \
+	CONFIG_NF_CONNTRACK_IRC \
+	CONFIG_NF_NAT_IRC
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_irc.ko \
+	$(LINUX_DIR)/net/$(P_XT)nf_nat_irc.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_irc nf_nat_irc)
+  DEPENDS:=+kmod-nf-nat
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-irc))
+
+
+define KernelPackage/nf-nathelper-netbios
+  SUBMENU:=$(NF_MENU)
+  TITLE:=NetBIOS NS conntrack helper
+  KCONFIG:=CONFIG_NF_CONNTRACK_NETBIOS_NS
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_netbios_ns.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_netbios_ns)
+  DEPENDS:=+kmod-nf-conntrack +kmod-nf-nathelper-broadcast
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-netbios))
+
+
+define KernelPackage/nf-nathelper-pptp
+  SUBMENU:=$(NF_MENU)
+  TITLE:=PPTP conntrack and NAT helper
+  KCONFIG:= \
+	CONFIG_NF_CONNTRACK_PPTP \
+	CONFIG_NF_NAT_PPTP
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_pptp.ko \
+	$(LINUX_DIR)/net/$(P_V4)nf_nat_pptp.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_pptp nf_nat_pptp)
+  DEPENDS:=+kmod-nf-nat
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-pptp))
+
+
+define KernelPackage/nf-nathelper-sane
+  SUBMENU:=$(NF_MENU)
+  TITLE:=SANE conntrack helper
+  KCONFIG:=CONFIG_NF_CONNTRACK_SANE
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_sane.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_sane)
+  DEPENDS:=+kmod-nf-conntrack
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-sane))
+
+
+define KernelPackage/nf-nathelper-sip
+  SUBMENU:=$(NF_MENU)
+  TITLE:=SIP conntrack and NAT helper
+  KCONFIG:= \
+	CONFIG_NF_CONNTRACK_SIP \
+	CONFIG_NF_NAT_SIP
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_sip.ko \
+	$(LINUX_DIR)/net/$(P_XT)nf_nat_sip.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_sip nf_nat_sip)
+  DEPENDS:=+kmod-nf-nat +kmod-nf-conntrack
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-sip))
+
+
+define KernelPackage/nf-nathelper-snmp
+  SUBMENU:=$(NF_MENU)
+  TITLE:=SNMP conntrack and NAT helper
+  KCONFIG:= \
+	CONFIG_NF_CONNTRACK_SNMP \
+	CONFIG_NF_NAT_SNMP_BASIC
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_snmp.ko \
+	$(LINUX_DIR)/net/$(P_V4)nf_nat_snmp_basic.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_snmp nf_nat_snmp_basic)
+  DEPENDS:= \
+	+kmod-asn1-decoder \
+	+kmod-nf-nat \
+	+kmod-nf-nathelper-broadcast
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-snmp))
+
+
+define KernelPackage/nf-nathelper-tftp
+  SUBMENU:=$(NF_MENU)
+  TITLE:=TFTP conntrack and NAT helper
+  KCONFIG:= \
+	CONFIG_NF_CONNTRACK_TFTP \
+	CONFIG_NF_NAT_TFTP
+  FILES:= \
+	$(LINUX_DIR)/net/$(P_XT)nf_conntrack_tftp.ko \
+	$(LINUX_DIR)/net/$(P_XT)nf_nat_tftp.ko
+  AUTOLOAD:=$(call AutoProbe,nf_conntrack_tftp nf_nat_tftp)
+  DEPENDS:=+kmod-nf-nat
+endef
+
+$(eval $(call KernelPackage,nf-nathelper-tftp))
 
 
 define KernelPackage/ipt-nflog


### PR DESCRIPTION
Split kmod-nf-nathelper-extra into separate helper packages and keep the original package as a compatibility meta-package.

This allows selecting only the required protocol helpers instead of installing all helper modules and dependencies.
